### PR TITLE
Use MPI_Type_get_extent instead of deprecated MPI_Type_extent

### DIFF
--- a/librecv_dynsize.cpp
+++ b/librecv_dynsize.cpp
@@ -252,8 +252,8 @@ int DYN_Recv(MPI_Datatype datatype, int src, int tag, MPI_Comm comm,
     MPI_Status stat;
     MPI_Probe(src, tag, comm, &stat);
     MPI_Get_count(&stat, datatype, count);
-    MPI_Aint extent;
-    MPI_Type_extent(datatype, &extent);
+    MPI_Aint extent, lb;
+    MPI_Type_get_extent(datatype, &lb, &extent);
     *buf = malloc(extent**count);
     MPI_Request req;
     MPI_Irecv(*buf, *count, datatype, src, tag, comm, &req);
@@ -268,8 +268,8 @@ int DYN_Recv(MPI_Datatype datatype, int src, int tag, MPI_Comm comm,
     MPI_Status stat;
     MPI_Probe(src, tag, comm, &stat);
     MPI_Get_count(&stat, datatype, count);
-    MPI_Aint extent;
-    MPI_Type_extent(datatype, &extent);
+    MPI_Aint extent, lb;
+    MPI_Type_get_extent(datatype, &lb, &extent);
     *buf = malloc(extent**count);
     MPI_Request req;
     MPI_Irecv(*buf, *count, datatype, src, tag, comm, &req);
@@ -284,8 +284,8 @@ int DYN_Recv(MPI_Datatype datatype, int src, int tag, MPI_Comm comm,
     MPI_Status stat;
     MPI_Probe(src, tag, comm, &stat);
     MPI_Get_count(&stat, datatype, count);
-    MPI_Aint extent;
-    MPI_Type_extent(datatype, &extent);
+    MPI_Aint extent, lb;
+    MPI_Type_get_extent(datatype, &lb, &extent);
     *buf = malloc(extent**count);
     MPI_Request req;
     MPI_Irecv(*buf, *count, datatype, src, tag, comm, &req);
@@ -300,8 +300,8 @@ int DYN_Recv(MPI_Datatype datatype, int src, int tag, MPI_Comm comm,
     MPI_Status stat;
     MPI_Probe(src, tag, comm, &stat);
     MPI_Get_count(&stat, datatype, count);
-    MPI_Aint extent;
-    MPI_Type_extent(datatype, &extent);
+    MPI_Aint extent, lb;
+    MPI_Type_get_extent(datatype, &lb, &extent);
     *buf = malloc(extent**count);
     MPI_Request req;
     MPI_Irecv(*buf, *count, datatype, src, tag, comm, &req);
@@ -335,8 +335,8 @@ int DYN_Irecv(MPI_Datatype datatype, int src, int tag, MPI_Comm comm,
     MPI_Iprobe(src, tag, comm, flag, &stat);
     if(*flag) {
       MPI_Get_count(&stat, datatype, count);
-      MPI_Aint extent;
-      MPI_Type_extent(datatype, &extent);
+      MPI_Aint extent, lb;
+      MPI_Type_get_extent(datatype, &lb, &extent);
       *buf = malloc(extent**count);
       MPI_Irecv(*buf, *count, datatype, src, tag, comm, req);
     }
@@ -350,8 +350,8 @@ int DYN_Irecv(MPI_Datatype datatype, int src, int tag, MPI_Comm comm,
     MPI_Iprobe(src, tag, comm, flag, &stat);
     if(*flag) {
       MPI_Get_count(&stat, datatype, count);
-      MPI_Aint extent;
-      MPI_Type_extent(datatype, &extent);
+      MPI_Aint extent, lb;
+      MPI_Type_get_extent(datatype, &lb, &extent);
       *buf = malloc(extent**count);
       MPI_Irecv(*buf, *count, datatype, src, tag, comm, req);
     }
@@ -365,8 +365,8 @@ int DYN_Irecv(MPI_Datatype datatype, int src, int tag, MPI_Comm comm,
     MPI_Iprobe(src, tag, comm, flag, &stat);
     if(*flag) {
       MPI_Get_count(&stat, datatype, count);
-      MPI_Aint extent;
-      MPI_Type_extent(datatype, &extent);
+      MPI_Aint extent, lb;
+      MPI_Type_get_extent(datatype, &lb, &extent);
       *buf = malloc(extent**count);
       MPI_Irecv(*buf, *count, datatype, src, tag, comm, req);
     }
@@ -380,8 +380,8 @@ int DYN_Irecv(MPI_Datatype datatype, int src, int tag, MPI_Comm comm,
     MPI_Iprobe(src, tag, comm, flag, &stat);
     if(*flag) {
       MPI_Get_count(&stat, datatype, count);
-      MPI_Aint extent;
-      MPI_Type_extent(datatype, &extent);
+      MPI_Aint extent, lb;
+      MPI_Type_get_extent(datatype, &lb, &extent);
       *buf = malloc(extent**count);
       MPI_Irecv(*buf, *count, datatype, src, tag, comm, req);
     }
@@ -408,8 +408,8 @@ int DYN_Recv(MPI_Datatype datatype, int src, int tag, MPI_Comm comm,
   MPI_Status stat;
   MPI_Probe(src, tag, comm, &stat);
   MPI_Get_count(&stat, datatype, count);
-  MPI_Aint extent;
-  MPI_Type_extent(datatype, &extent);
+  MPI_Aint extent, lb;
+  MPI_Type_get_extent(datatype, &lb, &extent);
   *buf = malloc(extent**count);
   MPI_Request req;
   MPI_Irecv(*buf, *count, datatype, src, tag, comm, &req);
@@ -424,8 +424,8 @@ int DYN_Irecv(MPI_Datatype datatype, int src, int tag, MPI_Comm comm,
   MPI_Iprobe(src, tag, comm, flag, &stat);
   if(*flag) {
     MPI_Get_count(&stat, datatype, count);
-    MPI_Aint extent;
-    MPI_Type_extent(datatype, &extent);
+    MPI_Aint extent, lb;
+    MPI_Type_get_extent(datatype, &lb, &extent);
     *buf = malloc(extent**count);
     MPI_Irecv(*buf, *count, datatype, src, tag, comm, req);
   }
@@ -451,8 +451,8 @@ int DYN_Recv(MPI_Datatype datatype, int src, int tag, MPI_Comm comm,
 
   MPI_Mprobe(src, tag, comm, &msg, &stat);
   MPI_Get_count(&stat, datatype, count);
-  MPI_Aint extent;
-  MPI_Type_extent(datatype, &extent);
+  MPI_Aint extent, lb;
+  MPI_Type_get_extent(datatype, &lb, &extent);
   *buf = malloc(extent**count);
   MPI_Request req;
   MPI_Imrecv(*buf, *count, datatype, &msg, &req);
@@ -469,8 +469,8 @@ int DYN_Irecv(MPI_Datatype datatype, int src, int tag, MPI_Comm comm,
   MPI_Improbe(src, tag, comm, flag, &msg, &stat);
   if(*flag) {
     MPI_Get_count(&stat, datatype, count);
-    MPI_Aint extent;
-    MPI_Type_extent(datatype, &extent);
+    MPI_Aint extent, lb;
+    MPI_Type_get_extent(datatype, &lb, &extent);
     *buf = malloc(extent**count);
     MPI_Imrecv(*buf, *count, datatype, &msg, req);
   }


### PR DESCRIPTION
`MPI_Type_extent` was removed and replaced with `MPI_Type_get_extent`